### PR TITLE
embark-define-keymap has been removed

### DIFF
--- a/README.org
+++ b/README.org
@@ -137,34 +137,34 @@ enable =consult-notes-org-headings-mode= and the headings for files you specify 
 If you use [[https://github.com/oantolin/embark][embark]] you can integrate consult-notes actions with embark like so: 
 
 #+begin_src emacs-lisp
-(defun consult-notes-open-dired (cand)
-  "Open notes directory dired with point on file CAND."
-  (interactive "fNote: ")
-  ;; dired-jump is in dired-x.el but is moved to dired in Emacs 28
-  (dired-jump nil cand))
+  (defun consult-notes-open-dired (cand)
+    "Open notes directory dired with point on file CAND."
+    (interactive "fNote: ")
+    ;; dired-jump is in dired-x.el but is moved to dired in Emacs 28
+    (dired-jump nil cand))
 
-(defun consult-notes-marked (cand)
-  "Open a notes file CAND in Marked 2.
-Marked 2 is a mac app that renders markdown."
-  (interactive "fNote: ")
-  (call-process-shell-command (format "open -a \"Marked 2\" \"%s\"" (expand-file-name cand))))
+  (defun consult-notes-marked (cand)
+    "Open a notes file CAND in Marked 2.
+  Marked 2 is a mac app that renders markdown."
+    (interactive "fNote: ")
+    (call-process-shell-command (format "open -a \"Marked 2\" \"%s\"" (expand-file-name cand))))
 
-(defun consult-notes-grep (cand)
-  "Run grep in directory of notes file CAND."
-  (interactive "fNote: ")
-  (consult-grep (file-name-directory cand)))
+  (defun consult-notes-grep (cand)
+    "Run grep in directory of notes file CAND."
+    (interactive "fNote: ")
+    (consult-grep (file-name-directory cand)))
 
-(embark-define-keymap consult-notes-map
-                      "Keymap for Embark notes actions."
-                      :parent embark-file-map
-                      ("d" consult-notes-dired)
-                      ("g" consult-notes-grep)
-                      ("m" consult-notes-marked))
+  (defvar-keymap consult-notes-map
+    :doc "Keymap for Embark notes actions."
+    :parent embark-file-map
+    "d" #'consult-notes-dired
+    "g" #'consult-notes-grep
+    "m" #'consult-notes-marked)
 
-(add-to-list 'embark-keymap-alist `(,consult-notes-category . consult-notes-map))
+  (add-to-list 'embark-keymap-alist `(,consult-notes-category . consult-notes-map))
 
-;; make embark-export use dired for notes
-(setf (alist-get consult-notes-category embark-exporters-alist) #'embark-export-dired)
+  ;; make embark-export use dired for notes
+  (setf (alist-get consult-notes-category embark-exporters-alist) #'embark-export-dired)
 #+end_src
 
 * Citar Support


### PR DESCRIPTION
Embark removed that macro in favor of using the future built-in `defvar-keymap`, which is available in older Emacsen through the compat library (which all consult users have installed anyway).