### PR TITLE
Rj/fix categories

### DIFF
--- a/README.org
+++ b/README.org
@@ -167,7 +167,7 @@ If you use [[https://github.com/oantolin/embark][embark]] you can integrate cons
   (defvar-keymap consult-notes-map
     :doc "Keymap for Embark notes actions."
     :parent embark-file-map
-    "d" #'consult-notes-dired
+    "d" #'consult-notes-open-dired
     "g" #'consult-notes-grep
     "m" #'consult-notes-marked)
 

--- a/consult-notes-denote.el
+++ b/consult-notes-denote.el
@@ -58,7 +58,7 @@
 (defconst consult-notes-denote--source
   (list :name     (propertize "Denote notes" 'face 'consult-notes-sep)
         :narrow   ?d
-        :category 'consult-notes-category
+        :category consult-notes-category
         :annotate #'consult-notes-denote--annotate
         :items    (lambda ()
                     (let* ((max-width 0)

--- a/consult-notes-org-headings.el
+++ b/consult-notes-org-headings.el
@@ -143,7 +143,7 @@ FIND-FILE is the file open function, defaulting to `find-file'."
 (defconst consult-notes-org-headings--source
   (list :name (propertize "Org Headings" 'face 'consult-notes-sep)
         :narrow consult-org-headings-narrow-key
-        :category 'consult-notes
+        :category consult-notes-category
         :require-match t
         :items (lambda ()
                  (consult-notes--org-headings t (consult-notes-org-headings-files)))


### PR DESCRIPTION
two things:
- the readme example for embark didn't use the right function symbol
- there's some inconsistency in the category used by some notes. this manifested when trying to use embark commands with the tool
- this thing is awesome!