### PR TITLE
Add configuration options to `consult-notes-denote--source'

### DIFF
--- a/README.org
+++ b/README.org
@@ -94,9 +94,10 @@ adds your =denote-directory= files to =consult-notes-all-sources=. Second, it se
 the display of denote files in consult slightly differently, in the format of
 =ID Title #keywords /directory size date modified=. ID, title, keywords, and
 directory are all searchable. If you like you can customize variables to hide
-the ID and directory. Third, the minor mode sets the default function when there
-is no match to create a denote note. Turning off the minor mode resets the
-defaults.
+the ID and directory, change the margin between the title and the keywords, or
+to adjust the way in which the keywords and directory are displayed. Third, the
+minor mode sets the default function when there is no match to create a denote
+note. Turning off the minor mode resets the defaults.
 
 Please note that if you use denote with siloed directories then you need to
 modify the default =dir-locals.el= file so as use a string rather than the

--- a/consult-notes-denote.el
+++ b/consult-notes-denote.el
@@ -63,6 +63,23 @@ details."
   :group 'consult-notes
   :type 'function)
 
+(defcustom consult-notes-denote-display-keywords-function #'consult-notes-denote--display-keywords
+  "Function to display the keywords of the file in the annotations for `consult-notes-denote'."
+  :group 'consult-notes
+  :type 'function)
+
+(defcustom consult-notes-denote-display-dir-function #'consult-notes-denote--display-dir
+  "Function used to display the directory name of the file in the annotations for `consult-notes-denote'.
+
+This function is only called when `consult-notes-denote-dir' is not nil."
+  :group 'consult-notes
+  :type 'function)
+
+(defcustom consult-notes-denote-title-margin 24
+  "Margin between the title and the keywords in the annotations for `consult-notes-denote'."
+  :group 'consult-notes
+  :type 'integer)
+
 ;;;; Source
 (defconst consult-notes-denote--source
   (list :name     (propertize "Denote notes" 'face 'consult-notes-sep)
@@ -81,7 +98,7 @@ details."
                                                    (keywords (denote-extract-keywords-from-path f)))
                                               (let ((current-width (string-width title)))
                                                 (when (> current-width max-width)
-                                                  (setq max-width (+ 24 current-width))))
+                                                  (setq max-width (+ consult-notes-denote-title-margin current-width))))
                                               (propertize title 'denote-path f 'denote-keywords keywords)))
                                           (funcall consult-notes-denote-files-function))))
                       (mapcar (lambda (c)
@@ -91,17 +108,20 @@ details."
                                   (concat c
                                           ;; align keywords
                                           (propertize " " 'display `(space :align-to (+ left ,(+ 2 max-width))))
-                                          (format "%18s"
-                                                  (if keywords
-                                                      (concat (propertize "#" 'face 'consult-notes-name)
-                                                              (propertize (mapconcat 'identity keywords " ") 'face 'consult-notes-name))
-                                                    ""))
-                                          (when consult-notes-denote-dir (format "%18s" (propertize (concat "/" dirs) 'face 'consult-notes-name))))))
+					  (propertize (funcall consult-notes-denote-display-keywords-function keywords) 'face 'consult-notes-name)
+					  (when consult-notes-denote-dir
+					    (propertize (funcall consult-notes-denote-display-dir-function dirs) 'face 'consult-notes-name)))))
                               cands)))
         ;; Custom preview
         :state  #'consult-notes-denote--state
         ;; Create new note on match fail
         :new     #'consult-notes-denote--new-note))
+
+(defun consult-notes-denote--display-keywords (keywords)
+  (format "%18s" (if keywords (concat "#" (mapconcat 'identity keywords " ")) "")))
+
+(defun consult-notes-denote--display-dir (dirs)
+  (format "%18s" (concat "/" dirs)))
 
 (defun consult-notes-denote--file (cand)
   (format "%s" (get-text-property 0 'denote-path cand)))


### PR DESCRIPTION
`consult-notes-denote--source` lacked some configuration options for setting the margin between the title and the keywords, as well as defining how the keywords or directories are displayed. This PR adds these options. Note that these options have been defined with `defvar` for now, not `defcustom`, as I don't know what API you would prefer. Feel free to suggest changes. As an example, I have currently set

```elisp
(setq consult-notes-denote--display-dirs-function nil)
(setq consult-notes-denote--display-keywords-function
      (lambda (keywords)
        (if keywords (concat "#" (mapconcat 'identity keywords " #")) "")))
(setq consult-notes-denote--title-margin 3))
```

The option `consult-notes-denote--title-margin` should fix https://github.com/mclear-tools/consult-notes/issues/35.