### PR TITLE
Add `consult-notes-insert-link'

### DIFF
--- a/consult-notes-denote.el
+++ b/consult-notes-denote.el
@@ -158,5 +158,13 @@ Input \"foo\", then create \"id-foo\", file type is determined by
     (put-text-property 0 (length ftime) 'face 'consult-notes-time ftime)
     (format "%8s  %8s" fsize ftime)))
 
+(defun consult-notes-denote--insert-link (cand)
+  "Insert CAND in `consult-notes-denote' using `denote-link'."
+  (let* ((file (get-text-property 0 'denote-path cand))
+	 (file-type (denote-filetype-heuristics buffer-file-name))
+	 (description (denote--link-get-description file)))
+    (kill-buffer)
+    (denote-link file file-type description)))
+
 (provide 'consult-notes-denote)
 ;;; consult-notes-denote.el ends here

--- a/consult-notes.el
+++ b/consult-notes.el
@@ -327,6 +327,16 @@ Which search function is used depends on the value of `consult-notes-use-rg'."
                   :history 'consult-notes-history
                   :add-history (seq-some #'thing-at-point '(region symbol))))
 
+;;;###autoload
+(defun consult-notes-insert-link ()
+  "Find a file in a notes directory with consult-multi and insert it as a
+link."
+  (interactive)
+  (if (not (bound-and-true-p consult-notes-denote-mode))
+      (message "`consult-notes-insert-link' currently only supports `consult-notes-denote-mode'.")
+    (consult-notes `((,@consult-notes-denote--source
+		      :action ,#'consult-notes-denote--insert-link)))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Provide Consult Notes
 (provide 'consult-notes)


### PR DESCRIPTION
This is a small proof of concept for a `consult-notes-insert-link` function that works with Denote. I needed this functionality myself and noticed this was requested in https://github.com/mclear-tools/consult-notes/issues/42. As I only ever work with Denote, I am not that familiar with the code bases of the other libraries.

More generally, I have wanted to implement some kind of back link functionality for `consult-notes-denote`, but it seems this would require some refactoring of `consult-notes-denote--source`.