### PR TITLE
Fix denote keyword narrowing

### DIFF
--- a/consult-notes-denote.el
+++ b/consult-notes-denote.el
@@ -118,7 +118,7 @@ This function is only called when `consult-notes-denote-dir' is not nil."
         :new     #'consult-notes-denote--new-note))
 
 (defun consult-notes-denote--display-keywords (keywords)
-  (format "%18s" (if keywords (concat "#" (mapconcat 'identity keywords " ")) "")))
+  (format "%18s" (if keywords (concat "#" (mapconcat 'identity keywords " #")) "")))
 
 (defun consult-notes-denote--display-dir (dirs)
   (format "%18s" (concat "/" dirs)))


### PR DESCRIPTION
I noticed that when calling `consult-notes` only the first of the keyword have a `#` prepended on it and the latter don't. This PR would fix the minor error.