### PR TITLE
Add ability to hide folders inside consult-notes

### DIFF
--- a/README.org
+++ b/README.org
@@ -70,7 +70,7 @@ Optionally you can add =:hidden t= to hide particular folder from default list p
 #+begin_src emacs-lisp
 (setq consult-notes-file-dir-sources
       '(("Visible"        ?o "~/Dropbox/org-files/visible/")
-        ("Hiden"          ?r "~/Dropbox/org-files/hidden/" :hidden t)))
+        ("Hidden"          ?r "~/Dropbox/org-files/hidden/" :hidden t)))
 #+end_src
 
 *NOTE*: If you don't use any sources beyond that of files in directories, then you don't need to set anything other than =consult-notes-file-dir-sources=. Org-roam or denote sources are set by using the relevant minor-mode (see below). However, if you /do/ want to integrate other different kinds of sources (e.g. bookmarks or buffers) into =consult-notes= then please see the instructions for adding [[https://github.com/minad/consult#multiple-sources][multiple sources with consult]]. To add an additional non-directory source one should do so by means of =add-to-list= in one's config, e.g.

--- a/README.org
+++ b/README.org
@@ -66,6 +66,13 @@ directory path. For example (note the trailing slashes):
 integrated consult completion buffer. To narrow to a particular source, use its
 designated narrowing key.
 
+Optionally you can add =:hidden t= to hide particular folder from default list presented by =consult-multi=. The folder will be still available via it's narrowing key.
+#+begin_src emacs-lisp
+(setq consult-notes-file-dir-sources
+      '(("Visible"        ?o "~/Dropbox/org-files/visible/")
+        ("Hiden"          ?r "~/Dropbox/org-files/hidden/" :hidden t)))
+#+end_src
+
 *NOTE*: If you don't use any sources beyond that of files in directories, then you don't need to set anything other than =consult-notes-file-dir-sources=. Org-roam or denote sources are set by using the relevant minor-mode (see below). However, if you /do/ want to integrate other different kinds of sources (e.g. bookmarks or buffers) into =consult-notes= then please see the instructions for adding [[https://github.com/minad/consult#multiple-sources][multiple sources with consult]]. To add an additional non-directory source one should do so by means of =add-to-list= in one's config, e.g.
 
 #+begin_src emacs-lisp

--- a/consult-notes.el
+++ b/consult-notes.el
@@ -171,27 +171,29 @@ a relative age."
 
 ;;;; Consult-Notes File-Directory Function
 ;;;###autoload
-(defun consult-notes--file-dir-source (name char dir)
+(defun consult-notes--file-dir-source (name char dir &rest args)
   "Generate the notes source for each directory of files in `consult-notes-dir-sources'.
 
  Return a notes source list suitable for `consult--multi'.
 NAME is the source name, CHAR is the narrowing character,
 and DIR is the directory to find notes."
-  `(:name     ,(propertize name 'face 'consult-notes-sep)
-    :narrow   ,char
-    :category ,consult-notes-category
-    :face     consult-file
-    :annotate ,(apply-partially consult-notes-file-dir-annotate-function name dir)
-    :items    ,(lambda ()
-                 (let* ((files (directory-files dir nil consult-notes-file-match)))
-                   files))
-    :state    ,(lambda ()
-                 (let ((open (consult--temporary-files))
-                       (state (consult--file-state)))
-                   (lambda (action cand)
-                     (unless cand
-                       (funcall open))
-                     (funcall state action (and cand (concat (file-name-as-directory dir) cand))))))))
+  (let ((hidden (plist-get args :hidden)))
+    `(:name     ,(propertize name 'face 'consult-notes-sep)
+      :narrow   ,char
+      :category ,consult-notes-category
+      :face     consult-file
+      :annotate ,(apply-partially consult-notes-file-dir-annotate-function name dir)
+      :hidden   ,hidden
+      :items    ,(lambda ()
+                  (let* ((files (directory-files dir nil consult-notes-file-match)))
+                    files))
+      :state    ,(lambda ()
+                  (let ((open (consult--temporary-files))
+                        (state (consult--file-state)))
+                    (lambda (action cand)
+                      (unless cand
+                        (funcall open))
+                      (funcall state action (and cand (concat (file-name-as-directory dir) cand)))))))))
 
 ;;;; Consult-Notes File Dir Annotation Function
 ;;;###autoload


### PR DESCRIPTION
Hey, I've implemented a way to hide specific folders by default in the consult list (they are still accessible via narrowing key). 

This can be extended in the future to support other keyword options handled by consult (eg. `:preview-key`) 