### PR TITLE
Add support for denote silos configuration

### DIFF
--- a/consult-notes.el
+++ b/consult-notes.el
@@ -232,12 +232,15 @@ and DIR is the directory to find notes."
   (require 'consult-notes-denote)
   ;; Add or remove denote notes from sources
   (cond (consult-notes-denote-mode
+         (when (not consult-notes-denote-silos)
+           (setq consult-notes-denote-silos `(("Denote notes" ?d ,denote-directory))))
+
          ;; Add denote notes source to consult--multi integration
-         (add-to-list 'consult-notes-all-sources 'consult-notes-denote--source 'append)
+         (consult-notes-denote--make-silos-sources)
          (setq consult-notes-file-action #'consult-notes-denote--new-note))
         (t
          ;; Remove denote notes from sources
-         (delete 'consult-notes-denote--source consult-notes-all-sources)
+         (consult-notes-denote--remove-sources)
          ;; Revert default new action
          (custom-reevaluate-setting 'consult-notes-file-action))))
 


### PR DESCRIPTION
Hi!

This PR introduces the addition of denote silos #63. 

If the user wants to create a new source for each silo, they will need to specify the name, key, and path to use in the creation of the source as shown below and activate the `consult-notes-denote-mode`:

```
(setq consult-notes-denote-silos
      '(("Silo1" ?a "~/Documents/silos/silo1")
        ("Silo2" ?b "~/Documents/silos/silo2/")
        ("Silo3" ?c "~/Documents/silos/silo3/")))
```

If `consult-notes-denote-silos` is `nil`, it will default to using the `denote-directory` variable to create the source, maintaining the previous behavior.

Here's a screenshot:
![image](https://github.com/user-attachments/assets/7477d41e-832a-44d5-bcad-454fffe726a8)

P.S. I apologize for any mistakes, as I am not very well-versed in elisp.